### PR TITLE
Update load statement in bazel.md for xcodeproj

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -9,7 +9,7 @@ For example, to use the [`xcodeproj`](#xcodeproj) rule, you would need to use
 this `load` statement:
 
 ```starlark
-load("@rules_xcodeproj//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcodeproj")
 ```
 
 ### Index


### PR DESCRIPTION
Isn't it more intuitive to use `defz.bzl` when presenting the core rules? 

:xcodeproj.bzl gets useless fast when trying to use top_level_target.bzl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Bazel setup guide to reflect the current rules_xcodeproj load path, ensuring examples match the latest usage and reducing setup confusion.
  * Clarified example configuration while preserving existing behavior.
  * No changes to public APIs or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->